### PR TITLE
Fix flaky behavior in generating MethodCallExpr and Consequence

### DIFF
--- a/drools-base/src/main/java/org/drools/base/rule/accessor/DeclarationScopeResolver.java
+++ b/drools-base/src/main/java/org/drools/base/rule/accessor/DeclarationScopeResolver.java
@@ -109,7 +109,7 @@ public class DeclarationScopeResolver {
 
     public Declaration getDeclaration(String identifier) {
         // it may be a local bound variable
-        for (final Iterator<RuleConditionElement> iterator = buildList.descendingIterator(); iterator.hasNext();) {
+        for (final Iterator<RuleConditionElement> iterator = buildList.iterator(); iterator.hasNext();) {
             final Declaration declaration = iterator.next().resolveDeclaration( identifier );
             if ( declaration != null ) {
                 return declaration;

--- a/drools-commands/pom.xml
+++ b/drools-commands/pom.xml
@@ -55,11 +55,11 @@
             <artifactId>jakarta.xml.bind-api</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
+	    <dependency>
+	      <groupId>org.junit.jupiter</groupId>
+	      <artifactId>junit-jupiter</artifactId>
+	      <scope>test</scope>
+	    </dependency>    
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>

--- a/drools-commands/src/test/java/org/drools/commands/DeleteCommandTest.java
+++ b/drools-commands/src/test/java/org/drools/commands/DeleteCommandTest.java
@@ -22,9 +22,9 @@ import org.drools.commands.runtime.rule.DeleteCommand;
 import org.drools.commands.runtime.rule.InsertObjectCommand;
 import org.drools.kiesession.rulebase.InternalKnowledgeBase;
 import org.drools.kiesession.rulebase.KnowledgeBaseFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.kie.api.runtime.Context;
 import org.kie.api.runtime.ExecutableRunner;
 import org.kie.api.runtime.KieSession;
@@ -40,7 +40,7 @@ public class DeleteCommandTest {
     private ExecutableRunner<RequestContext> runner;
     private Context context;
 
-    @Before
+    @BeforeEach
     public void setup() {
         InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
         ksession = kbase.newKieSession();
@@ -48,7 +48,7 @@ public class DeleteCommandTest {
         context = ((RegistryContext) runner.createContext()).register(KieSession.class, ksession);
     }
 
-    @After
+    @AfterEach
     public void cleanUp() {
         ksession.dispose();
     }

--- a/drools-commands/src/test/java/org/drools/commands/ExecuteCommandDisconnectedTest.java
+++ b/drools-commands/src/test/java/org/drools/commands/ExecuteCommandDisconnectedTest.java
@@ -25,7 +25,7 @@ import org.drools.commands.runtime.rule.InsertObjectCommand;
 import org.drools.core.common.DefaultFactHandle;
 import org.drools.commands.runtime.ExecutionResultImpl;
 import org.drools.kiesession.rulebase.KnowledgeBaseFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.kie.api.KieBase;
 import org.kie.api.command.BatchExecutionCommand;
 import org.kie.api.runtime.ExecutableRunner;

--- a/drools-commands/src/test/java/org/drools/commands/FromExternalFactHandleCommandTest.java
+++ b/drools-commands/src/test/java/org/drools/commands/FromExternalFactHandleCommandTest.java
@@ -21,9 +21,8 @@ package org.drools.commands;
 import org.drools.commands.runtime.rule.FromExternalFactHandleCommand;
 import org.drools.kiesession.rulebase.InternalKnowledgeBase;
 import org.drools.kiesession.rulebase.KnowledgeBaseFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.kie.api.runtime.Context;
 import org.kie.api.runtime.ExecutableRunner;
 import org.kie.api.runtime.KieSession;
@@ -39,7 +38,7 @@ public class FromExternalFactHandleCommandTest {
     private ExecutableRunner<RequestContext> runner;
     private Context context;
 
-    @Before
+    @BeforeEach
     public void setup() {
         InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
         ksession = kbase.newKieSession();
@@ -47,12 +46,12 @@ public class FromExternalFactHandleCommandTest {
         context = ((RegistryContext) runner.createContext()).register(KieSession.class, ksession);
     }
 
-    @After
+    @AfterEach
     public void cleanUp() {
         ksession.dispose();
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     public void testFromExternalFactHandleCommandNumberFormatException() {
         // DROOLS-7076 : Just to test not to throw NumberFormatException 
         String externalFormat = "0:2147483648:171497379:-1361525545:2147483648:null:NON_TRAIT:java.lang.String";

--- a/drools-commands/src/test/java/org/drools/commands/GetFactHandlesCommandTest.java
+++ b/drools-commands/src/test/java/org/drools/commands/GetFactHandlesCommandTest.java
@@ -27,9 +27,9 @@ import org.drools.commands.runtime.rule.GetFactHandlesCommand;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.kiesession.rulebase.InternalKnowledgeBase;
 import org.drools.kiesession.rulebase.KnowledgeBaseFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.kie.api.runtime.Context;
 import org.kie.api.runtime.ExecutableRunner;
 import org.kie.api.runtime.KieSession;
@@ -47,7 +47,7 @@ public class GetFactHandlesCommandTest {
     private Context context;
     private Random random = new Random();
     
-    @Before
+    @BeforeEach
     public void setup() { 
         InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
         ksession = kbase.newKieSession();
@@ -55,7 +55,7 @@ public class GetFactHandlesCommandTest {
         context = ( (RegistryContext) runner.createContext() ).register( KieSession.class, ksession );
     }
     
-    @After
+    @AfterEach
     public void cleanUp() { 
        ksession.dispose(); 
     }

--- a/drools-commands/src/test/java/org/drools/commands/InternalExecutableTest.java
+++ b/drools-commands/src/test/java/org/drools/commands/InternalExecutableTest.java
@@ -25,7 +25,7 @@ import org.drools.commands.fluent.Batch;
 import org.drools.commands.fluent.BatchImpl;
 import org.drools.commands.fluent.InternalExecutable;
 import org.drools.commands.impl.NotTransactionalCommand;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.kie.api.command.ExecutableCommand;
 import org.kie.api.runtime.Context;
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/NotTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/NotTest.java
@@ -311,4 +311,26 @@ public class NotTest {
         assertThat(results.size()).isEqualTo(1);
         assertThat(results.get(0)).isEqualTo("Paris");
     }
+
+    @Test
+    public void testNotWithUnification() {
+        // DROOLS-7629
+        final String drl =
+                "package org.drools.compiler.integrationtests.operators;\n" +
+                "rule R1 when\n" +
+                "      ( not ( $rao_v2 := String() and (\n" +
+                "          $rao_v2 := String()\n" +
+                "      ) ) and (\n" +
+                "         $rao_v2 := String()\n" +
+                "      )\n" +
+                "   )\n" +
+                "then\n" +
+                "end";
+
+        final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("not-test", kieBaseTestConfiguration, drl);
+        final KieSession ksession = kbase.newKieSession();
+
+        ksession.insert("test");
+        assertThat(ksession.fireAllRules()).isEqualTo(0);
+    }
 }


### PR DESCRIPTION
This PR addresses a flaky behavior that can be shown when running tests: AccumulateTest#BindingOrderWithInlineAccumulateAndLists 
AccumulateTest#testInlineAccumulateWithAnd
This is caused by the non-deterministic behavior of unordered Set collections. The original implementations of creating Consequence object, which later used to construct MethodCallExpr, used a Set to track and filter used arguments. The order of the arguments is important during rule compilation. This inconsistency surfaced as a flaky behavior when running with NonDex, casuing Drools to fail to compile the generated Java file.

Fix:
The solution replaces the Set with a TreeSet in the Consequence#extractUsedDeclarations method to ensure that the order of arguments is stable.

