### PR TITLE
Fix flaky behavior when generating Consequence

### DIFF
--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/Consequence.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/Consequence.java
@@ -23,10 +23,12 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import com.github.javaparser.ParseProblemException;
 import com.github.javaparser.ast.Modifier;
@@ -65,7 +67,6 @@ import org.drools.mvelcompiler.PreprocessCompiler;
 import org.drools.util.StringUtils;
 
 import static com.github.javaparser.StaticJavaParser.parseExpression;
-import static java.util.stream.Collectors.toSet;
 import static org.drools.model.codegen.execmodel.PackageModel.DOMAIN_CLASSESS_METADATA_FILE_NAME;
 import static org.drools.model.codegen.execmodel.PackageModel.DOMAIN_CLASS_METADATA_INSTANCE;
 import static org.drools.model.codegen.execmodel.generator.DrlxParseUtil.addCurlyBracesToBlock;
@@ -251,7 +252,7 @@ public class Consequence {
     }
 
     private Set<String> extractUsedDeclarations(BlockStmt ruleConsequence, String consequenceString) {
-        Set<String> existingDecls = new HashSet<>();
+        Set<String> existingDecls = new LinkedHashSet<>();
         existingDecls.addAll(context.getAvailableBindings());
         existingDecls.addAll(context.getGlobals().keySet());
         if (context.getRuleUnitDescr() != null) {
@@ -259,10 +260,14 @@ public class Consequence {
         }
 
         if (context.getRuleDialect() == RuleContext.RuleDialect.MVEL) {
-            return existingDecls.stream().filter(d -> containsWord(d, consequenceString)).collect(toSet());
+            return existingDecls.stream()
+                                .filter(d -> containsWord(d, consequenceString))
+                                .collect(Collectors.toCollection(LinkedHashSet::new));
         } else if (ruleConsequence != null) {
-            Set<String> declUsedInRHS = ruleConsequence.findAll(NameExpr.class).stream().map(NameExpr::getNameAsString).collect(toSet());
-            return existingDecls.stream().filter(declUsedInRHS::contains).collect(toSet());
+            Set<String> declUsedInRHS = ruleConsequence.findAll(NameExpr.class).stream().map(NameExpr::getNameAsString).collect(Collectors.toCollection(LinkedHashSet::new));
+            return existingDecls.stream()
+                                .filter(declUsedInRHS::contains)
+                                .collect(Collectors.toCollection(LinkedHashSet::new));
         }
 
         throw new IllegalArgumentException("Unknown rule dialect " + context.getRuleDialect() + "!");


### PR DESCRIPTION
This PR addresses a flaky behavior that can be shown when running tests with NonDex: 

`AccumulateTest#BindingOrderWithInlineAccumulateAndLists`
`AccumulateTest#testInlineAccumulateWithAnd`

> [Message [id=1, level=ERROR, path=src/main/java/defaultpkg/RulesB950FF693D054B8A666934B470D397E9RuleMethods0.java, line=65, column=6973
>    text=The method execute(Block2<List,Set>) in the type ConsequenceBuilder._2<List,Set> is not applicable for the arguments (LambdaConsequence48F5B19427621706C23CE016D5184C97)], Message [id=2, level=ERROR, path=src/main/java/defaultpkg/RulesB950FF693D054B8A666934B470D397E9RuleMethods0.java, line=0, column=0
>    text=Java source of src/main/java/defaultpkg/RulesB950FF693D054B8A666934B470D397E9RuleMethods0.java in error:

The error message show that the parameter is not applicable for the arguments of LambdaConsequence, which was essentially constructed by the MethodCallExpr and Consequence. 

By enabling `EclipseJavaCompiler#dumpUnits()`, we can see that, while using NonDex to shuffling orders, the LambdaConsequence* java file that are generated can have a flaky behavior for it's `execute()` method, where the order of the method parameters can be non-deterministic. And this behavior caused the above compilation error. 

The original implementations of creating Consequence object, which later used to construct MethodCallExpr, used a Set to track and filter arguments. However, the order of the arguments is important during rule compilation. This inconsistency surfaced as a flaky behavior when running with NonDex, casuing Drools to fail to compile the generated Java file.

Fix:
The solution replaces the Set with a LinkedHashSet in the `Consequence#extractUsedDeclarations `method to ensure that the order of arguments is stable.